### PR TITLE
Fixed os dependent path creation

### DIFF
--- a/pcloudpy/gui/MainWindowBase.py
+++ b/pcloudpy/gui/MainWindowBase.py
@@ -287,7 +287,7 @@ class MainWindowBase(QMainWindow):
             data = yaml.load(text)
         else:
             path = os.path.dirname(os.path.realpath(__file__))
-            with open(os.path.join(path,'resources\conf\config_toolboxes.yaml'), 'r') as f:
+            with open(os.path.join(path,'resources', 'conf', 'config_toolboxes.yaml'), 'r') as f:
                 # use safe_load instead load
                 data = yaml.safe_load(f)
 


### PR DESCRIPTION
Using "\" in paths is not valid for unix systems like Ubuntu; thats why pcloudpy crashed on Linux Mint 18 on startup; using multiple strings avoids this problem as the appropriate separator will be used